### PR TITLE
Add -s option to optionally display device serial numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ streaming-capable conversion of gptid to device name
 
 ```
 # ./gptconv.py -h
-usage: gptconv.py [-h] [-d] [-p] [-o [outfile]] [infile]
+usage: gptconv.py [-h] [-d] [-s] [-p] [-o [outfile]] [infile]
 
 convert gptid to device name
 
@@ -13,6 +13,7 @@ positional arguments:
 optional arguments:
   -h, --help    show this help message and exit
   -d            Insert disk description
+  -s            Insert disk serial number
   -p            Do not try to fix padding on output
   -o [outfile]  Output file (omit for stdout)
 ```

--- a/gptconv.py
+++ b/gptconv.py
@@ -3,7 +3,13 @@
 # gptconv.py
 # streaming-capable conversion of gptid to device name
 #
-# Version: 1.0 (2020-04-19)
+# Version: 1.1 (2020-10-03)
+#
+# Version History:
+# 1.1 - Added -s option to print serial numbers
+#     - Added extra space when exceeding original width of field when not
+#       in -p mode
+# 1.0 - Initial release
 #
 # This is only intended to work on FreeNAS / TrueNAS CORE.
 # This tool is not provided, sponsored, endorsed, or supported by iXsystems.


### PR DESCRIPTION
Added a -s option to optionally display device serial numbers, similar to -d for device names. Fixes #1 

Adding an additional space to replacement field when its length exceeds the width of the original gptid field to try to maintain field separation. This is not done when -p is used, for better or worse.